### PR TITLE
Tweak to work with Ubuntu 22.04.

### DIFF
--- a/ext/rdkit_chem/extconf.rb
+++ b/ext/rdkit_chem/extconf.rb
@@ -62,7 +62,7 @@ Dir.chdir build_dir do
   puts 'Configuring RDKit'
 
   cmake = "#{ld_path} cmake #{src_dir} -DRDK_INSTALL_INTREE=OFF " \
-          "-DCMAKE_INSTALL_PREFIX=#{install_dir} " \
+          "-DCMAKE_INSTALL_PREFIX=#{install_dir} -DRDK_BUILD_CPP_TESTS=OFF" \
           '-DCMAKE_BUILD_TYPE=Release -DRDK_BUILD_PYTHON_WRAPPERS=OFF ' \
           '-DRDK_BUILD_SWIG_WRAPPERS=ON -DRDK_BUILD_INCHI_SUPPORT=OFF ' \
           '-DBoost_NO_BOOST_CMAKE=ON'


### PR DESCRIPTION
Ubuntu 21.10 (onwards) uses libc6 (glibc) 2.34, which introduced a major ABI change. SIGSTKSZ is now no longer constant, and can’t be used directly to define array sizes.